### PR TITLE
Remove type:'module' from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "source": "src/index.tsx",
-  "type": "module",
   "types": "dist/index.d.ts",
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
Removing type:"module" from package.json will fix the no exports found issue