### PR TITLE
Add esm build using microbundle-crl

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,17 +8,17 @@
     "type": "git",
     "url": "https://github.com/cuongdevjs/reactjs-social-login"
   },
+  "type": "module",
   "main": "dist/index.js",
-  "module": "dist/index.js",
+  "module": "dist/index.modern.js",
   "typings": "dist/index.d.ts",
   "source": "src/index.tsx",
-  "type": "module",
   "types": "dist/index.d.ts",
   "engines": {
     "node": ">=10"
   },
   "scripts": {
-    "build": "microbundle-crl --format cjs",
+    "build": "microbundle-crl --format modern,esm,cjs",
     "start": "microbundle-crl watch --format cjs",
     "prepare": "run-s build",
     "test": "run-s test:unit test:lint test:build",


### PR DESCRIPTION
The previous fix will not actually work for cra and custom webpack setup, since react app mostly use esm imports as well this package is not meant for server side rendering, esm will be quiet helpful. I've made a change so that the microbundle-crl will generate esm build files. I've tried to generate both esm and cjs bundles but unfortunately it's not working on microbundle-crl. It should be a breeze when using esbuild.

This will actually fix the module not exported error for many users. I confirmed it several times before the PR

