### PR TITLE
fix: remove google script on dismount to get a new client instance after remount

### DIFF
--- a/src/LoginSocialGoogle/index.tsx
+++ b/src/LoginSocialGoogle/index.tsx
@@ -76,6 +76,12 @@ const LoginSocialGoogle = forwardRef(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isSdkLoaded])
 
+    useEffect(() => {
+      return () => {
+        document.getElementById(SCRIPT_ID)?.remove()
+      }
+    }, [])
+
     const checkIsExistsSDKScript = useCallback(() => {
       return !!document.getElementById(SCRIPT_ID)
     }, [])


### PR DESCRIPTION
This PR is for this issue: https://github.com/cuongdevjs/reactjs-social-login/issues/54

When the LoginSocialGoogle mounted a 2nd time, the client instance was missing so `requestAccessToken` wouldn't be called anymore.

By removing the script in a useEffect cleanup function, a new script and client instance will be created when the component mounts again.