### PR TITLE
docs: use correct channel names in comments

### DIFF
--- a/src/LoginSocialPinterest/index.tsx
+++ b/src/LoginSocialPinterest/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 /**
  *
- * LoginSocialGithub
+ * LoginSocialPinterest
  *
  */
 import { PASS_CORS_KEY } from 'helper/constants';

--- a/src/LoginSocialTwitter/index.tsx
+++ b/src/LoginSocialTwitter/index.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable camelcase */
 /**
  *
- * LoginSocialGithub
+ * LoginSocialTwitter
  *
  */
 import { PASS_CORS_KEY } from 'helper/constants';


### PR DESCRIPTION
The channel names were probably copy pasted and then not changed. This updates them to be correct.