### PR TITLE
Error Callback Handler for Google Provider

### DIFF
--- a/src/LoginSocialGoogle/index.tsx
+++ b/src/LoginSocialGoogle/index.tsx
@@ -174,6 +174,16 @@ const LoginSocialGoogle = ({
     [isOnlyGetToken, onGetMe, onResolve],
   );
 
+  const handleError = useCallback(
+    (res: objectType) => {
+      onReject({
+        provider: 'google',
+        data: res,
+      });
+    },
+    [onReject],
+  );
+
   const load = useCallback(() => {
     if (checkIsExistsSDKScript()) {
       setIsSdkLoaded(true);
@@ -189,6 +199,7 @@ const LoginSocialGoogle = ({
             ...params,
             auto_select,
             callback: handleResponse,
+            error_callback: handleError,
           });
         } else {
           client = _window.google.accounts.oauth2.initTokenClient({
@@ -204,10 +215,9 @@ const LoginSocialGoogle = ({
             immediate: true,
             fetch_basic_profile,
             callback: handleResponse,
+            error_callback: handleError,
           });
         }
-
-
 
         if (client) setInstance(client);
         setIsSdkLoaded(true);
@@ -227,6 +237,7 @@ const LoginSocialGoogle = ({
     cookie_policy,
     hosted_domain,
     handleResponse,
+    handleError,
     fetch_basic_profile,
     insertScriptGoogle,
     checkIsExistsSDKScript,


### PR DESCRIPTION
**Background:** 
Currently, when a non-Oauth error occurs in the Google flow (eg: The user closes the modal), no callback will be triggered by the Google component. Other components like Facebook and Apple do account for these cases in this same project.


**Summary of changes**: 
- Following the google [documentation](https://developers.google.com/identity/oauth2/web/guides/error#non-oauth_errors),added the property called `error_callback` that will be triggrered for these cases. 
- Changes should not break the current API for this library as it will trigger the `onReject` handler that already exists.


**Screenshots**
<img width="770" alt="Screenshot 2023-07-14 at 20 24 36" src="https://github.com/cuongdevjs/reactjs-social-login/assets/19997625/af27484b-a641-4774-bca4-58fc786d261f">

