### PR TITLE
Issue with Microsoft Login. Authentication was not being registered on first click

### DIFF
--- a/src/LoginSocialMicrosoft/index.tsx
+++ b/src/LoginSocialMicrosoft/index.tsx
@@ -137,9 +137,9 @@ export const LoginSocialMicrosoft = ({
   );
 
   const onChangeLocalStorage = useCallback(() => {
-    window.removeEventListener('storage', onChangeLocalStorage, false);
     const code = localStorage.getItem('microsoft');
     if (code) {
+      window.removeEventListener('storage', onChangeLocalStorage, false);
       handlePostMessage({ provider: 'microsoft', type: 'code', code });
       localStorage.removeItem('microsoft');
     }


### PR DESCRIPTION
Linked to Issue #163 

Fix an issue with Microsoft where the user had to click on login a second time for his login to register with the app. This was caused by a too early removal of the 'storage' event listener

The fix is quite simple really; we just have to make sure that 'code' exists before removing the listener and then everything works perfectly.