### PR TITLE
Update index.tsx

### DIFF
--- a/src/LoginSocialLinkedin/index.tsx
+++ b/src/LoginSocialLinkedin/index.tsx
@@ -58,7 +58,7 @@ export const LoginSocialLinkedin = ({
       fetch(
         `https://api.allorigins.win/get?url=${encodeURIComponent(
           LINKEDIN_API_URL +
-            '/v2/me?oauth2_access_token=' +
+            '/v2/userinfo?oauth2_access_token=' +
             data.access_token +
             '&projection=(id,profilePicture(displayImage~digitalmediaAsset:playableStreams),localizedLastName, firstName,lastName,localizedFirstName)',
         )}`,


### PR DESCRIPTION
Update /v2/me ---> /v2/userinfo base on new update in linked in Sign In Policy,  ---------------------
This version of Sign In with LinkedIn has been deprecated as of August 1, 2023. For all Sign In with LinkedIn implementations going forward, please refer to Sign In with LinkedIn using OpenID Connect. ---------------------
Now End Point is  /v2/userinfo